### PR TITLE
fixed bugs in data_process_start_stop function

### DIFF
--- a/R/analyse_MACE.R
+++ b/R/analyse_MACE.R
@@ -93,12 +93,18 @@ data_process_start_stop <- function(data) {
 
   data$t_mace_start <- 0
   data$t_mace_stop <- ifelse(data$event_disc==1,data$t_disc,ifelse(data$event_mace==1,data$t_mace,1))
-
+  data$event_mace <- ifelse(data$event_disc==1,0,data$event_mace)
+  
   data2$t_mace_start <- data2$t_disc
   data2$t_mace_stop <- data2$t_mace
   data2$disc <- 1
-
-  return(rbind(data,data2)|>arrange(ID,t_mace_start))
+  
+  if (mean(data2$t_mace_start==data2$t_mace_stop)==1) {
+    return(data)
+  } else {
+    return(rbind(data,data2)|>arrange(ID,t_mace_start))
+  }
+  
 }
 
 


### PR DESCRIPTION
Hi,

I fixed two bugs in the data_process_start_stop function :

- for individuals with a mace event inside their buffer window, event_mace was set to 1 in both time periods

- Errors would show up with assumed_window = 0 :

Before, rows with discontinuation and no withdrawal would get duplicated to account for the buffer window after discontinuation. However, with assumed_window = 0, rows would get duplicated with t_mace_start = t_mace_stop, which would produce errors, so I added a check to not add these rows