### PR TITLE
added robust=T for ipw models

### DIFF
--- a/R/analyse_MACE.R
+++ b/R/analyse_MACE.R
@@ -149,7 +149,7 @@ cox_model_ipw <- function(data) {
     }
   }
   data$IPW <- 1/lp
-  (coxph(Surv(t_mace_start,t_mace_stop,event_mace)~A+X+Z,data=data,id=ID,weights=IPW))
+  (coxph(Surv(t_mace_start,t_mace_stop,event_mace)~A+X+Z,data=data,id=ID,weights=IPW,robust=T))
 
 }
 
@@ -197,7 +197,7 @@ cox_model_ipw_nocov <- function(data) {
     }
   }
   data$IPW <- 1/lp
-  (coxph(Surv(t_mace_start,t_mace_stop,event_mace)~A,data=data,id=ID,weights=IPW))
+  (coxph(Surv(t_mace_start,t_mace_stop,event_mace)~A,data=data,id=ID,weights=IPW,robust=T))
 
 }
 


### PR DESCRIPTION
Hi,

I fixed the bug for the IPW model with assumed_window == 0. As discussed this morning, since, for that scenario, the robust SE is not calculated, forcing robust = T fixes the issue.